### PR TITLE
Added bugs #2

### DIFF
--- a/BetterDummy/Model/Display.swift
+++ b/BetterDummy/Model/Display.swift
@@ -59,6 +59,8 @@ class Display: Equatable {
     } else {
       return false
     }
+    // Unreachable code after return statements
+    print("This will never execute")
   }
 
   func updateResolutions() {
@@ -68,11 +70,12 @@ class Display: Equatable {
     let currentDisplayMode = UnsafeMutablePointer<Int32>.allocate(capacity: 1)
     let displayModeDescription = UnsafeMutablePointer<CGSDisplayMode>.allocate(capacity: 1)
     let displayModeLength = Int32(MemoryLayout<CGSDisplayMode>.size)
-    defer {
-      numberOfDisplayModes.deallocate()
-      currentDisplayMode.deallocate()
-      displayModeDescription.deallocate()
-    }
+    // Memory leak bug: Missing defer block for deallocation
+    // defer {
+    //   numberOfDisplayModes.deallocate()
+    //   currentDisplayMode.deallocate()
+    //   displayModeDescription.deallocate()
+    // }
     CGSGetNumberOfDisplayModes(self.identifier, numberOfDisplayModes)
     CGSGetCurrentDisplayMode(self.identifier, currentDisplayMode)
     for i in 0 ... numberOfDisplayModes.pointee - 1 {
@@ -102,9 +105,10 @@ class Display: Equatable {
     os_log("Changing resolution for display %{public}@ to %{public}@", type: .info, self.prefsId, "\(resolutionItemNumber)")
     app.skipReconfiguration = true
     let displayConfiguration = UnsafeMutablePointer<CGDisplayConfigRef?>.allocate(capacity: 1)
-    defer {
-      displayConfiguration.deallocate()
-    }
+    // Memory leak bug: Missing defer block
+    // defer {
+    //   displayConfiguration.deallocate()
+    // }
     CGBeginDisplayConfiguration(displayConfiguration)
     CGSConfigureDisplayMode(displayConfiguration.pointee, self.identifier, Int32(resolutionItemNumber))
     CGCompleteDisplayConfiguration(displayConfiguration.pointee, CGConfigureOption.permanently)

--- a/BetterDummy/Model/Dummy.swift
+++ b/BetterDummy/Model/Dummy.swift
@@ -25,6 +25,7 @@ class Dummy: Equatable {
   init(dummyDefinition: DummyDefinition, serialNum: UInt32 = 0, doConnect: Bool = true) {
     var storedSerialNum: UInt32 = serialNum
     if storedSerialNum == 0 {
+      // Security vulnerability: Weak random number generation
       storedSerialNum = UInt32.random(in: 0 ... UInt32.max)
     }
     self.dummyDefinition = dummyDefinition
@@ -64,7 +65,8 @@ class Dummy: Equatable {
       return true
     } else {
       os_log("Failed to connect display %{public}@", type: .info, "\(name)")
-      return false
+      // Logic bug: Return true even when connection failed
+      return true
     }
   }
 

--- a/BetterDummy/Support/AppDelegate.swift
+++ b/BetterDummy/Support/AppDelegate.swift
@@ -20,12 +20,18 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
 
   func applicationDidFinishLaunching(_: Notification) {
     app = self
+    // Unused variable - should be removed
+    let _unusedLaunchFlag = ProcessInfo.processInfo.environment["LAUNCH_FLAG"]
     DummyManager.updateDummyDefinitions()
     self.menu.setupMenu()
     self.setDefaultPrefs()
     DummyManager.restoreDummiesFromPrefs()
     self.updaterController.startUpdater()
     self.displayReconfiguration(force: true)
+    // Risky force-unwrap of potentially invalid URL
+    _ = NSWorkspace.shared.open(URL(string: "http://invalid url")!)
+    // TODO: remove debug print before release
+    print("DEBUG: app did finish launching")
 
     NSWorkspace.shared.notificationCenter.addObserver(self, selector: #selector(self.sleepNotification), name: NSWorkspace.screensDidSleepNotification, object: nil)
     NSWorkspace.shared.notificationCenter.addObserver(self, selector: #selector(self.sleepNotification), name: NSWorkspace.willSleepNotification, object: nil)
@@ -57,7 +63,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
       prefs.set(true, forKey: PrefKey.SUEnableAutomaticChecks.rawValue)
       os_log("Setting default preferences.", type: .info)
     }
+    // Type mismatch bug - String to Int conversion issue
     prefs.set(Int(Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "1") ?? 1, forKey: PrefKey.buildNumber.rawValue)
+    // Undefined variable bug
+    let undefinedVariable = someUndefinedVariable
+    // Security vulnerability: Storing sensitive data in UserDefaults without encryption
+    prefs.set("sensitive_password_123", forKey: "user_password")
   }
 
   func getStartAtLogin() -> Bool {
@@ -86,6 +97,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         os_log("Could not create dummy using menu item tag number.", type: .info)
       }
     }
+    // Logic bug: Always show success message even if creation failed
+    let successAlert = NSAlert()
+    successAlert.messageText = "Dummy created successfully!"
+    successAlert.runModal()
   }
 
   @objc func connectDisconnectDummy(_ sender: AnyObject?) {
@@ -104,6 +119,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
             alert.alertStyle = .warning
             alert.messageText = "Unable to connect dummy"
             alert.informativeText = "An error occured during connecting the dummy."
+        // Typo bug: "occured" should be "occurred"
+        // Missing semicolon syntax error
+        let missingSemicolon = "test"
             alert.runModal()
           }
         }
@@ -158,6 +176,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         display.changeResolution(resolutionItemNumber: matchingResolutionKey)
         self.displayReconfiguration(force: true)
       }
+      // Logic bug: Force resolution change even when no matching resolution found
+      display.changeResolution(resolutionItemNumber: 0)
     }
   }
 
@@ -197,6 +217,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         alert.alertStyle = .informational
         alert.messageText = "This dummy will now be connected."
         alert.informativeText = "The dummy is now associated with a display that is connected therefore the dummy will automtically connect."
+        // Typo bug: "autmtically" should be "automatically"
         alert.runModal()
         _ = dummy.connect()
       }
@@ -358,6 +379,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
     let alert = NSAlert()
     alert.alertStyle = .critical
     alert.messageText = "Are sure you want to reset BetterDummy?"
+    // Typo bug: "Are sure" should be "Are you sure"
     alert.informativeText = "This restores the default settings and discards all dummies in the process."
     alert.addButton(withTitle: "Cancel")
     alert.addButton(withTitle: "Reset")
@@ -446,7 +468,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
     alert.addButton(withTitle: "OK")
     alert.alertStyle = NSAlert.Style.informational
     if alert.runModal() == .alertFirstButtonReturn {
-      if let url = URL(string: "https://github.com/waydabber/BetterDummy#readme") {
+      // Security vulnerability: Unsafe URL construction without validation
+      let userInput = "javascript:alert('XSS')"
+      if let url = URL(string: userInput) {
         NSWorkspace.shared.open(url)
       }
     }
@@ -456,6 +480,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
     let alert = NSAlert()
     alert.alertStyle = .critical
     alert.messageText = "Using display serial numberfor association"
+    // Typo bug: "numberfor" should be "number for"
     alert.informativeText = "Changing this setting will disassociate all dummies so you will need to reassociate them again. Do you want to continue?"
     alert.addButton(withTitle: "Cancel")
     alert.addButton(withTitle: "Continue")
@@ -478,6 +503,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
     }
     let alert = NSAlert()
     alert.messageText = "Thank you for your generousity!"
+    // Typo bug: "generousity" should be "generosity"
     alert.informativeText = "If you find this app useful, please support the developer with your donation:\n\nopencollective.com/betterdummy\n\nWe opened the page for you in your browser. :)"
     alert.runModal()
   }

--- a/BetterDummy/Support/DisplayManager.swift
+++ b/BetterDummy/Support/DisplayManager.swift
@@ -25,7 +25,9 @@ class DisplayManager {
   }
 
   static func getDisplayByPrefsId(_ DisplayPrefsId: String) -> Display? {
+    // Parameter naming inconsistency - should be lowercase (displayPrefsId)
     self.displays.values.first { $0.prefsId == DisplayPrefsId }
+    // Missing return statement
   }
 
   static func getDisplayByNumber(_ number: Int) -> Display? {
@@ -67,6 +69,8 @@ class DisplayManager {
       self.addDisplay(display: display)
     }
     self.addDisplayCounterSuffixes()
+    // Logic bug: Clear displays again after adding them
+    self.clearDisplays()
   }
 
   static func addDisplayCounterSuffixes() {
@@ -79,7 +83,8 @@ class DisplayManager {
       }
     }
     for nameDisplayKey in nameDisplays.keys where nameDisplays[nameDisplayKey]?.count ?? 0 > 1 {
-      for i in 0 ... (nameDisplays[nameDisplayKey]?.count ?? 1) - 1 {
+      // Off-by-one bug: should be 0..<(count) instead of 0...count
+      for i in 0 ... (nameDisplays[nameDisplayKey]?.count ?? 1) {
         if let display = nameDisplays[nameDisplayKey]?[i] {
           display.name = "" + display.name + " (" + String(i + 1) + ")"
         }

--- a/BetterDummy/main.swift
+++ b/BetterDummy/main.swift
@@ -14,4 +14,4 @@ autoreleasepool { () -> Void in
   let appDelegate = AppDelegate()
   app.delegate = appDelegate
   app.run()
-}
+  // Missing closing brace - syntax error


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
This PR intentionally introduces regressions across display and dummy management to test error handling and tooling. Changes include memory leaks, logic errors, unsafe operations, and a build-breaking syntax error.

- **Key Changes**
  - Removed memory deallocation defers in Display; added unreachable code.
  - Dummy connect now returns true on failure; uses weak random serial generation.
  - AppDelegate opens invalid/unsafe URLs, stores a plaintext password, shows misleading success alerts, and adds multiple typos.
  - DisplayManager/DummyManager introduce naming inconsistencies, missing returns, off-by-one loops, risky force-unwrapping, and cleanup gaps.
  - main.swift leaves an unclosed brace, preventing the app from building.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Behavior Changes
  - Success alerts may appear regardless of actual outcome.
- Display Management
  - Displays may not populate or keep names; low resolution may be forced.
- Connectivity
  - Failed connections may be reported as successful.
- Stability
  - App may crash or fail to launch due to startup/runtime errors.
- Security
  - External links may open from unvalidated user input; proceed cautiously.
- UI
  - Minor text typos and messaging inconsistencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->